### PR TITLE
chore: fix parameters in server error log

### DIFF
--- a/engine/main.go
+++ b/engine/main.go
@@ -158,10 +158,9 @@ func main() {
 
 	//calc.logger.Info("API on :443, metrics on :9000 — press Ctrl-C to stop")
 	calc.logger.Info("API on " + addr + ", metrics on " + metricsAddr + " — press Ctrl-C to stop")
-
 	// wait for error OR signal
 	if err := g.Wait(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-		calc.logger.Error("server error: %v\n", err)
+		calc.logger.Error("server error", "error", err)
 	}
 
 }


### PR DESCRIPTION
This happens on latest `main`:
```
% go test . -v
# github.com/collapsinghierarchy/encproc
# [github.com/collapsinghierarchy/encproc]
./main.go:164:43: slog.Logger.Error arg "err" should be a string or a slog.Attr (possible missing key or value)
FAIL	github.com/collapsinghierarchy/encproc [build failed]
FAIL
```

After this fix:
```
% go test . -v
=== RUN   TestInitAggregator_Success
--- PASS: TestInitAggregator_Success (0.01s)
=== RUN   TestInitAggregator_BadParamsJSON
--- PASS: TestInitAggregator_BadParamsJSON (0.00s)
=== RUN   TestInitAggregator_BadPK
--- PASS: TestInitAggregator_BadPK (0.01s)
=== RUN   TestSnapshotAggregate_NilCiphertext
--- PASS: TestSnapshotAggregate_NilCiphertext (0.00s)
=== RUN   TestAggregate_FirstCiphertext
--- PASS: TestAggregate_FirstCiphertext (0.00s)
=== RUN   TestAggregate_BadCiphertext
--- PASS: TestAggregate_BadCiphertext (0.00s)
=== RUN   TestAggregate_AddCiphertext
--- PASS: TestAggregate_AddCiphertext (0.00s)
=== RUN   TestHandlers_Aggregator_AggregationFlow
    handlers_test.go:46: Stream ID: 7CB426997F
contributeAggregate: id=7CB426997F
agg_map.Load: id=7CB426997F, found=true
contributeAggregate: id=7CB426997F
agg_map.Load: id=7CB426997F, found=true
    handlers_test.go:71: Using stream ID: 7CB426997F
--- PASS: TestHandlers_Aggregator_AggregationFlow (0.01s)
PASS
ok  	github.com/collapsinghierarchy/encproc	0.289s

```