### PR TITLE
chore: surface BGV evaluator errors on add operations

### DIFF
--- a/engine/aggregator.go
+++ b/engine/aggregator.go
@@ -91,8 +91,11 @@ func (agg *aggregator) aggregate(ct_bin []byte) error {
 		return nil
 	}
 
-	agg.eval.Add(agg.ct_aggr, ct, agg.ct_aggr)
-	agg.ctr++
+	if err := agg.eval.Add(agg.ct_aggr, ct, agg.ct_aggr); err != nil {
+		agg.logger.Error("failed to add ciphertext", "error", err)
+		return err
+	}
 
+	agg.ctr++
 	return nil
 }


### PR DESCRIPTION
Ensure that lattigo errors in the BGV evaluator get propagated to the aggregator during add operations:

Function signature [here](https://github.com/tuneinsight/lattigo/blob/main/schemes/bgv/evaluator.go#L177).